### PR TITLE
Support prompt caching, structured and unstructured system prompt and messages

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Check formatting
+        run: cargo fmt -- --check

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,10 +15,10 @@ pub enum AnthropicError {
 
     /// Unexpected response format
     InvalidResponse(String),
-    
+
     /// Rate limit exceeded
     RateLimitExceeded { retry_after: Option<u64> },
-    
+
     /// Authentication error
     AuthenticationError(String),
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -59,8 +59,17 @@ pub struct Message {
     /// Role of the message sender (user, assistant, system)
     pub role: String,
 
-    /// Content of the message as vector of MessageContent objects
-    pub content: Vec<MessageContent>,
+    /// Content of the message - can be a string or vector of MessageContent objects
+    pub content: MessageContentFormat,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum MessageContentFormat {
+    /// Simple string format
+    String(String),
+    /// Structured content format
+    Structured(Vec<MessageContent>),
 }
 
 impl Message {
@@ -68,7 +77,7 @@ impl Message {
     pub fn new_structured(role: impl Into<String>, content: Vec<MessageContent>) -> Self {
         Self {
             role: role.into(),
-            content,
+            content: MessageContentFormat::Structured(content),
         }
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -3,6 +3,33 @@ use crate::tool_choice::ToolChoice;
 use mcp_protocol::tool::{Tool, ToolContent};
 use serde::{Deserialize, Serialize};
 
+/// Cache control configuration for system messages
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CacheControl {
+    #[serde(rename = "type")]
+    pub cache_type: String,
+}
+
+/// A single system message with optional cache control
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SystemMessage {
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+/// Different types of system messages that can be provided
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum SystemMessageFormat {
+    /// Simple string format
+    String(String),
+    /// Array of structured system messages
+    Array(Vec<SystemMessage>),
+}
+
 /// Different types of content that can be in a message
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
@@ -62,9 +89,9 @@ pub struct CompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
 
-    /// System prompt to use
+    /// System prompt to use (can be a string or array of structured messages)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub system: Option<String>,
+    pub system: Option<SystemMessageFormat>,
 
     /// Tools to make available to Claude
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -209,3 +209,52 @@ pub enum AnthropicResponse {
     /// Error response
     Error { error: String },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_completion_request_with_system_messages() {
+        let json = r#"{
+            "model": "claude-3-7-sonnet-20250219",
+            "max_tokens": 1024,
+            "system": [
+              {
+                "type": "text",
+                "text": "You are an AI assistant tasked with analyzing literary works. Your goal is to provide insightful commentary on themes, characters, and writing style.\n"
+              },
+              {
+                "type": "text",
+                "text": "<the entire contents of Pride and Prejudice>",
+                "cache_control": {"type": "ephemeral"}
+              }
+            ],
+            "messages": [
+              {
+                "role": "user",
+                "content": "Analyze the major themes in Pride and Prejudice."
+              }
+            ]
+          }"#;
+
+        serde_json::from_str::<CompletionRequest>(json).expect("Failed to deserialize request");
+    }
+
+    #[test]
+    fn test_deserialize_completion_request_with_system_message_string() {
+        let json = r#"{
+            "model": "claude-3-7-sonnet-20250219",
+            "max_tokens": 1024,
+            "system": "You are an AI assistant tasked with analyzing literary works. Your goal is to provide insightful commentary on themes, characters, and writing style.",
+            "messages": [
+              {
+                "role": "user",
+                "content": "Analyze the major themes in Pride and Prejudice."
+              }
+            ]
+        }"#;
+
+        serde_json::from_str::<CompletionRequest>(json).expect("Failed to deserialize request");
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,16 +5,16 @@ use serde::{Deserialize, Serialize};
 pub struct ModelInfo {
     /// Model ID
     pub id: String,
-    
+
     /// Display name
     pub display_name: String,
-    
+
     /// Maximum context window size
     pub max_tokens: u32,
-    
+
     /// Provider name
     pub provider: String,
-    
+
     /// Optional pricing information
     pub pricing: Option<ModelPricing>,
 }
@@ -24,7 +24,7 @@ pub struct ModelInfo {
 pub struct ModelPricing {
     /// Cost per million input tokens
     pub input_cost_per_million_tokens: f64,
-    
+
     /// Cost per million output tokens
     pub output_cost_per_million_tokens: f64,
 }
@@ -37,7 +37,7 @@ impl ModelInfo {
             "claude-3-7-sonnet-20250219" => 200000,
 
             // Claude 3.5 models
-            "claude-3-5-sonnet-20241022" 
+            "claude-3-5-sonnet-20241022"
             | "claude-3-5-haiku-20241022"
             | "claude-3-5-sonnet-20240620" => 200000,
 
@@ -53,7 +53,7 @@ impl ModelInfo {
             _ => 100000, // Conservative default
         }
     }
-    
+
     /// Get pricing information for a given model ID
     pub fn get_pricing(model_id: &str) -> ModelPricing {
         match model_id {


### PR DESCRIPTION
- Add support for prompt caching
- Add types for single-string message
- Add types for structured system prompt
- Add deserialisation unit test based on Anthropic docs

And some admin:

- Add a GitHub action that runs the unit tests, clippy, cargo fmt on commits to main
- Run cargo fmt